### PR TITLE
add get all entries handler

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -1,0 +1,16 @@
+import { db } from '../models/entry';
+
+const entries = db;
+
+export default {
+  getAllEntries(req, res, next) {
+    try {
+      res.send({
+        entries,
+        message: 'All Diary Entries Retrieved Successfully',
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+};

--- a/server/models/entry.js
+++ b/server/models/entry.js
@@ -1,0 +1,23 @@
+export const db = [
+  {
+    id: 1,
+    authorID: 1,
+    title: 'The Andela Way',
+    content: 'The Andela bootcamp is a popularly known program amongst programmers.',
+    createdAt: 1531513412307,
+    updatedAt: 1531513412307,
+  },
+];
+
+class Entry {
+  constructor(authorID, title, content) {
+    this.id = (db.length) + 1;
+    this.authorID = authorID;
+    this.title = title;
+    this.content = content;
+    this.createdAt = Date.now();
+    this.updatedAt = Date.now();
+  }
+}
+
+export default Entry;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -1,7 +1,9 @@
 import express from 'express';
+import entriesController from '../controllers/entriesController';
 
 const router = express.Router();
 
 router.get('/', (req, res) => res.status(200).json({ message: 'Welcome to my diary app' }));
+router.get('/entries', entriesController.getAllEntries);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
This pull request implements the get-all-entries functionality, which enables the user to get a list of all diary entries.

#### Description of task to be completed?

- Create an api route '/entries' to get all the diary entries of a user.

- Create a function to listen for get requests from the specified route and respond with a list of diary entries

#### How should this be manually tested?

- Clone project

- Open terminal, navigate to server folder and run: npm install

- After installation run: npm run dev

- Open Postman and setup a GET request with the url: http://localhost:3090/api/v1/entries

#### What are the relevant pivotal tracker stories?
[#159113329](https://www.pivotaltracker.com/story/show/159113329)

### Any background context you want to add?
N/A

### Screenshots
N/A