### PR TITLE
Add get-single-entry route and functionality

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -13,4 +13,21 @@ export default {
       next(error);
     }
   },
+  getEntry(req, res, next) {
+    try {
+      const entryID = parseInt(req.params.id, 10);
+      const entry = entries.filter(singleEntry => singleEntry.id === entryID);
+
+      if (entry.length === 1) {
+        res.send({
+          entry,
+          message: 'Diary Entry Retrieved Successfully',
+        });
+      } else {
+        res.status(404).send({ error: 'Entry not found' });
+      }
+    } catch (error) {
+      next(error);
+    }
+  },
 };

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -3,7 +3,7 @@ import entriesController from '../controllers/entriesController';
 
 const router = express.Router();
 
-router.get('/', (req, res) => res.status(200).json({ message: 'Welcome to my diary app' }));
 router.get('/entries', entriesController.getAllEntries);
+router.get('/entries/:id', entriesController.getEntry);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
This pull request implements the get-single-entry functionality, which enables the user to get a particular diary entry.

#### Description of task to be completed?

- Create an api route '/entries/:id' to get a specific diary entry of a user.

- Create a function to listen for get requests from the specified route and respond with a single diary entry

#### How should this be manually tested?

- Clone project

- Open terminal, navigate to server folder and run: npm install

- After installation run: npm run dev

- Open Postman and setup a GET request with the url: http://localhost:3090/api/v1/entries/1

#### What are the relevant pivotal tracker stories?
[#159113759](https://www.pivotaltracker.com/story/show/159113759)

### Any background context you want to add?
N/A

### Screenshots
N/A