### PR TITLE
Add delete entry route and functionality

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -1,6 +1,6 @@
 import Entry, { db } from '../models/entry';
 
-const entries = db;
+let entries = db;
 
 export default {
   getAllEntries(req, res, next) {
@@ -24,7 +24,7 @@ export default {
           message: 'Diary Entry Retrieved Successfully',
         });
       } else {
-        res.status(404).send({ error: 'Entry not found' });
+        res.status(404).send({ message: 'Entry not found' });
       }
     } catch (error) {
       next(error);
@@ -66,7 +66,25 @@ export default {
           message: 'Edited Diary Entry Successfully',
         });
       } else {
-        res.status(404).send({ error: 'Entry not found' });
+        res.status(404).send({ message: 'Entry not found' });
+      }
+    } catch (error) {
+      next(error);
+    }
+  },
+  deleteEntry(req, res, next) {
+    try {
+      const entryID = parseInt(req.params.id, 10);
+      const exists = entries.find(entry => entry.id === entryID);
+
+      if (exists) {
+        const newEntries = entries.filter(entry => entry.id !== entryID);
+        entries = newEntries;
+        res.send({
+          message: 'Deleted Diary Entry Successfully',
+        });
+      } else {
+        res.status(404).send({ message: 'Entry not found' });
       }
     } catch (error) {
       next(error);

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -8,6 +8,7 @@ router.get('/entries', entriesController.getAllEntries);
 router.get('/entries/:id', entriesController.getEntry);
 router.post('/entries', validate.entryPost, entriesController.createEntry);
 router.put('/entries/:id', validate.entryUpdate, entriesController.editEntry);
+router.delete('/entries/:id', entriesController.deleteEntry);
 
 router.all('*', (req, res) => {
   res.status(404).json({


### PR DESCRIPTION
#### What does this PR do?
This pull request implements the delete-entry functionality, which enables the user to delete an entry from the list of entries.

#### Description of task to be completed?

- Create an api route '/entries/:id' to delete a specified diary entry.

- Create a function to listen for DELETE requests from the specified route, delete the specified entry from the list of entries and respond with a message indicating that the entry has been successfully deleted.

#### How should this be manually tested?

- Clone project

- Open terminal, navigate to server folder and run: npm install

- After installation run: npm run dev

- Open Postman and setup a DELETE request with the url: http://localhost:3090/api/v1/entries/1

#### What are the relevant pivotal tracker stories?
[#159115424](https://www.pivotaltracker.com/story/show/159115424)

### Any background context you want to add?
N/A

### Screenshots
N/A