### PR TITLE
#159293101 add create entry functionality for users

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -1,8 +1,28 @@
-import Entry, { db } from '../models/entry';
+import Entry, { db as database } from '../models/entry';
+import db from '../db';
 
-let entries = db;
+let entries = database;
 
 export default {
+  createEntry(req, res, next) {
+    try {
+      const queryString = 'INSERT INTO public.entries(user_id, title, content, created, updated) VALUES ($1, $2, $3, $4, $5) RETURNING *';
+      const { id } = req.user;
+      const { title, content } = req.body;
+      const entry = new Entry(id, title, content);
+
+      db.query(queryString,
+        [entry.authorID, entry.title, entry.content, entry.createdAt, entry.updatedAt],
+        (err, result) => {
+          res.status(201).send({
+            entry: result.rows[0],
+            message: 'Diary Entry Created Successfully',
+          });
+        });
+    } catch (error) {
+      next(error);
+    }
+  },
   getAllEntries(req, res, next) {
     try {
       res.send({
@@ -28,19 +48,6 @@ export default {
       } else {
         res.status(404).send({ message: 'Entry not found' });
       }
-    } catch (error) {
-      next(error);
-    }
-  },
-  createEntry(req, res, next) {
-    try {
-      const { authorID, title, content } = req.body;
-      const entry = new Entry(authorID, title, content);
-      entries.push(entry);
-      res.status(201).send({
-        entry,
-        message: 'Diary Entry Created Successfully',
-      });
     } catch (error) {
       next(error);
     }

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -6,7 +6,29 @@ dotenv.config();
 const db = new pg.Pool({ connectionString: process.env.DEVELOPMENT });
 
 db.query(
-  'CREATE TABLE IF NOT EXISTS public.users (id SERIAL PRIMARY KEY, firstname character varying(100) NOT NULL, lastname character varying(100) NOT NULL, email character varying(100) NOT NULL, password character varying(100) NOT NULL)',
+  `
+CREATE TABLE public.users (
+id SERIAL PRIMARY KEY,
+firstname character varying(100) NOT NULL,
+lastname character varying(100) NOT NULL,
+email character varying(100) NOT NULL,
+password character varying(100) NOT NULL
+)
+  `,
+  () => { },
+);
+
+db.query(
+  `
+CREATE TABLE public.entries (
+id SERIAL PRIMARY KEY,
+user_id integer REFERENCES public.users,
+title character varying(100) NOT NULL,
+content character varying(255) NOT NULL,
+created bigint NOT NULL,
+updated bigint NOT NULL
+);
+  `,
   () => { },
 );
 

--- a/server/models/entry.js
+++ b/server/models/entry.js
@@ -11,7 +11,6 @@ export const db = [
 
 class Entry {
   constructor(authorID, title, content) {
-    this.id = (db.length) + 1;
     this.authorID = authorID;
     this.title = title;
     this.content = content;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -18,7 +18,7 @@ router.post('/auth/signin', validate.signinPost, requireSignin, authController.s
 
 /* main routes */
 
-router.post('/entries', validate.entryPost, requireAuth, entriesController.createEntry);
+router.post('/entries', requireAuth, validate.entryPost, entriesController.createEntry);
 
 router.get('/entries', entriesController.getAllEntries);
 router.get('/entries/:id', entriesController.getEntry);

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -8,6 +8,7 @@ import '../services/passport';
 
 const router = express.Router();
 
+const requireAuth = passport.authenticate('jwt', { session: false });
 const requireSignin = passport.authenticate('local', { session: false });
 
 /* auth routes */
@@ -17,9 +18,11 @@ router.post('/auth/signin', validate.signinPost, requireSignin, authController.s
 
 /* main routes */
 
+router.post('/entries', validate.entryPost, requireAuth, entriesController.createEntry);
+
 router.get('/entries', entriesController.getAllEntries);
 router.get('/entries/:id', entriesController.getEntry);
-router.post('/entries', validate.entryPost, entriesController.createEntry);
+
 router.put('/entries/:id', validate.entryUpdate, entriesController.editEntry);
 router.delete('/entries/:id', entriesController.deleteEntry);
 

--- a/server/services/passport.js
+++ b/server/services/passport.js
@@ -1,7 +1,11 @@
 import passport from 'passport';
 import LocalStrategy from 'passport-local';
+import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
+import dotenv from 'dotenv';
 import db from '../db';
 import bcrypt from '../helpers/bcrypt';
+
+dotenv.config();
 
 const localOptions = { usernameField: 'email' };
 const localLogin = new LocalStrategy(localOptions, (email, password, done) => {
@@ -20,4 +24,22 @@ const localLogin = new LocalStrategy(localOptions, (email, password, done) => {
   });
 });
 
+const jwtOptions = {
+  jwtFromRequest: ExtractJwt.fromHeader('authorization'),
+  secretOrKey: process.env.SECRET,
+};
+
+const jwtLogin = new JwtStrategy(jwtOptions, (payload, done) => {
+  db.query('SELECT * FROM users WHERE id=$1', [payload.sub], async (err, resp) => {
+    if (err) { return done(err, false); }
+
+    if (resp.rowCount > 0) {
+      done(null, resp.rows[0]);
+    } else {
+      done(null, false);
+    }
+  });
+});
+
+passport.use(jwtLogin);
 passport.use(localLogin);

--- a/server/test/entriesControllerTest.js
+++ b/server/test/entriesControllerTest.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import request from 'supertest';
-
+import db from '../db';
 import app from '..';
+
 import { resetTestDB } from '../controllers/entriesController';
 
 describe('Entries controller', () => {
@@ -9,54 +10,44 @@ describe('Entries controller', () => {
   let len;
 
   beforeEach(() => {
+    let token;
+
+    db.query('CREATE TABLE IF NOT EXISTS public.users (id SERIAL PRIMARY KEY, firstname character varying(100) NOT NULL, lastname character varying(100) NOT NULL, email character varying(100) NOT NULL, password character varying(100) NOT NULL)',
+      () => {},
+    );
+
+    db.query('CREATE TABLE public.entries (id SERIAL PRIMARY KEY, user_id integer REFERENCES public.users, title character varying(100) NOT NULL, content character varying(255) NOT NULL, created bigint NOT NULL, updated bigint NOT NULL',
+      () => {},
+    );
+
     testDB = resetTestDB();
     len = testDB.length
-  })
-
-  describe('GET all the entries', () => {
-    it('GET to /api/v1/entries should return all the diary entries', done => {
-      request(app)
-        .get('/api/v1/entries')
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.entries.length).to.equal(len);
-          expect(res.body.entries[0].title).to.equal('The Andela Way')
-          done();
-        });
-    });
-  });
-
-  describe('GET a single entry', () => {
-    it('GET to /api/v1/entries/1 should return a single diary entry', done => {
-      request(app)
-        .get('/api/v1/entries/1')
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.entry.title).to.equal('The Andela Way')
-          done();
-        });
-    });
-
-    it('should return an error when an entry is not found', done => {
-	  request(app)
-        .get('/api/v1/entries/2')
-        .end((err, res) => {
-          expect(res.status).to.equal(404);
-          expect(res.body.message).to.equal('Entry not found')
-          done();
-        });
-    });
   });
 
   describe('Creating an entry', () => {
     it('POST to /api/v1/entries should create a new diary entry', done => {
       request(app)
+        .post('/api/v1/auth/signup')
+        .send({
+          "email": "adinoyi@gmail.com",
+          "password": "myPassword",
+          "firstName": "Adinoyi",
+          "lastName": "Sadiq"
+        })
+        .end((err, res) => {
+          token = res.body.token
+          done();
+        });
+
+      request(app)
         .post('/api/v1/entries')
+        .set('Accept', 'application/json')
+        .set({ 'authorization': token, Accept: 'application/json' })
         .send({
           authorID: 1,
           title: 'A Year of Code',
           content: 'A few weeks ago, I marked a year since I started coding every day'
-		})
+        })
         .end((err, res) => {
           expect(res.status).to.equal(201);
           expect(res.body.message).to.equal('Diary Entry Created Successfully');
@@ -91,6 +82,41 @@ describe('Entries controller', () => {
         .end((err, res) => {
           expect(res.status).to.equal(400);
           expect(res.body.message).to.equal('Too many fields')
+          done();
+        });
+    });
+  });
+
+  describe('GET all the entries', () => {
+    it('GET to /api/v1/entries should return all the diary entries', done => {
+      request(app)
+        .get('/api/v1/entries')
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.entries.length).to.equal(len);
+          expect(res.body.entries[0].title).to.equal('The Andela Way')
+          done();
+        });
+    });
+  });
+
+  describe('GET a single entry', () => {
+    it('GET to /api/v1/entries/1 should return a single diary entry', done => {
+      request(app)
+        .get('/api/v1/entries/1')
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.entry.title).to.equal('The Andela Way')
+          done();
+        });
+    });
+
+    it('should return an error when an entry is not found', done => {
+	  request(app)
+        .get('/api/v1/entries/2')
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.body.message).to.equal('Entry not found')
           done();
         });
     });


### PR DESCRIPTION
### What does this PR do?
This pull request enables an authenticated user to add a new diary entry and view a list of their entries

#### Description of Task to be completed?
- Authenticate the create entries route
- Create a new entries table
- Refactor create Entries function to save to a database.
- Retrieve a list of Entries

#### How should this be manually tested?
Setup the application following the instructions in the README
Create an authenticated user and create a new entry using Postman
Finally, use the '/entries' route to get a list of entries from a particular user

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#159293101](https://www.pivotaltracker.com/story/show/159293101)
[#159292966](https://www.pivotaltracker.com/story/show/159292966)

#### Screenshots (if appropriate)
N/A

#### Questions:
None