### PR TITLE
#159293081 Add get single entry capability for users

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -39,21 +39,23 @@ export default {
   },
   getEntry(req, res, next) {
     try {
-      const queryString = 'SELECT * FROM entries WHERE user_id=$1';
+      const queryString = 'SELECT * FROM entries WHERE user_id=$1 AND id=$2';
       const entryID = parseInt(req.params.id, 10);
+      const { id } = req.user;
 
-      const singleEntry = entries.filter(entry => entry.id === entryID);
-
-      if (singleEntry.length === 1) {
-        res.send({
-          entry: singleEntry[0],
-          message: 'Diary Entry Retrieved Successfully',
-        });
-      } else if (singleEntry.length > 1) {
-        res.status(500).send({ error: 'An error occurred while retrieving the entry' });
-      } else {
-        res.status(404).send({ message: 'Entry not found' });
-      }
+      db.query(queryString, [id, entryID], (err, result) => {
+        const len = Object.keys(result.rows).length;
+        if (len === 1) {
+          res.send({
+            entry: result.rows[0],
+            message: 'Diary Entry Retrieved Successfully',
+          });
+        } else if (len > 1) {
+          res.status(500).send({ error: 'An error occurred while retrieving the entry' });
+        } else {
+          res.status(404).send({ message: 'Entry not found' });
+        }
+      });
     } catch (error) {
       next(error);
     }

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -19,9 +19,9 @@ router.post('/auth/signin', validate.signinPost, requireSignin, authController.s
 /* main routes */
 
 router.post('/entries', requireAuth, validate.entryPost, entriesController.createEntry);
-
 router.get('/entries', requireAuth, entriesController.getAllEntries);
-router.get('/entries/:id', entriesController.getEntry);
+
+router.get('/entries/:id', requireAuth, entriesController.getEntry);
 
 router.put('/entries/:id', validate.entryUpdate, entriesController.editEntry);
 router.delete('/entries/:id', entriesController.deleteEntry);

--- a/server/test/entriesControllerTest.js
+++ b/server/test/entriesControllerTest.js
@@ -20,6 +20,18 @@ describe('Entries controller', () => {
       () => {},
     );
 
+    afterEach(() => {
+      db.query('DROP TABLE public.users',
+        () => {},
+      )
+    });
+
+    afterEach(() => {
+      db.query('DROP TABLE public.entries',
+        () => {},
+      )
+    });
+
     testDB = resetTestDB();
     len = testDB.length
   });
@@ -89,8 +101,25 @@ describe('Entries controller', () => {
 
   describe('GET all the entries', () => {
     it('GET to /api/v1/entries should return all the diary entries', done => {
+      let token;
+
+      request(app)
+        .post('/api/v1/auth/signup')
+        .send({
+          "email": "adinoyi@gmail.com",
+          "password": "myPassword",
+          "firstName": "Adinoyi",
+          "lastName": "Sadiq"
+        })
+        .end((err, res) => {
+          token = res.body.token
+          done();
+        });
+
       request(app)
         .get('/api/v1/entries')
+        .set('Accept', 'application/json')
+        .set({ 'authorization': token, Accept: 'application/json' })
         .end((err, res) => {
           expect(res.status).to.equal(200);
           expect(res.body.entries.length).to.equal(len);
@@ -101,9 +130,28 @@ describe('Entries controller', () => {
   });
 
   describe('GET a single entry', () => {
+    beforeEach((done) => {
+      let token;
+      
+      request(app)
+        .post('/api/v1/auth/signup')
+        .send({
+          "email": "adinoyi@gmail.com",
+          "password": "myPassword",
+          "firstName": "Adinoyi",
+          "lastName": "Sadiq"
+        })
+        .end((err, res) => {
+          token = res.body.token
+          done();
+        });
+    })
+
     it('GET to /api/v1/entries/1 should return a single diary entry', done => {
       request(app)
         .get('/api/v1/entries/1')
+        .set('Accept', 'application/json')
+        .set({ 'authorization': token, Accept: 'application/json' })
         .end((err, res) => {
           expect(res.status).to.equal(200);
           expect(res.body.entry.title).to.equal('The Andela Way')
@@ -114,6 +162,8 @@ describe('Entries controller', () => {
     it('should return an error when an entry is not found', done => {
 	  request(app)
         .get('/api/v1/entries/2')
+        .set('Accept', 'application/json')
+        .set({ 'authorization': token, Accept: 'application/json' })
         .end((err, res) => {
           expect(res.status).to.equal(404);
           expect(res.body.message).to.equal('Entry not found')


### PR DESCRIPTION
### What does this PR do?
This pull request enables a user to get a single diary entry from the database.

#### Description of Task to be completed?
- Add an authenticated route for getting a single entry
- Refactor getEntry function to work with the database
- Add tests for getEntry route

#### How should this be manually tested?
- Setup the repository as instructed in the README
- Using Postman create an authorized user and create a diary entry
- Use the following route to retrieve the user '/entries/:id' 

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#159293081](https://www.pivotaltracker.com/story/show/159293081)

#### Screenshots (if appropriate)
N/A

#### Questions:
None

