### PR TITLE
#159714395 A user can update either the content or title field

### DIFF
--- a/server/controllers/entriesController.js
+++ b/server/controllers/entriesController.js
@@ -91,10 +91,16 @@ export default {
       const isNumber = !Number.isNaN(entryID);
       if (isNumber) {
         db.query('SELECT * FROM entries WHERE user_id=$1 AND id=$2', [id, entryID], (err, result) => {
+          const oldTitle = result.rows[0].title;
+          const oldContent = result.rows[0].content;
+
+          const newTitle = title ? title : oldTitle;
+          const newContent = content ? content : oldContent;
+
           const resultLength = Object.keys(result.rows).length;
           const valid = restrictUpdate(result.rows[0].created);
           if (resultLength === 1 && valid) {
-            db.query(queryString, [title, content, updatedAt, id, entryID], (error, resp) => {
+            db.query(queryString, [newTitle, newContent, updatedAt, id, entryID], (error, resp) => {
               res.send({
                 entry: resp.rows[0],
                 message: 'Edited Diary Entry Successfully',

--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -24,10 +24,7 @@ export default {
     const fieldLength = Object.keys(req.body).length;
     const missing = checkFields({ title, content });
 
-    if (missing.length > 0) {
-      if (missing.length === 1) {
-        return res.status(400).send({ message: `Please fill the ${missing[0]} field` });
-      }
+    if (missing.length === 2) {
       return res.status(400).send({ message: `Please fill the ${missing[0]} and ${missing[1]} fields` });
     }
 


### PR DESCRIPTION
### What does this PR do?
This pull request enables the user to pass in either the title or content field to update an entry

#### Description of Task to be completed?
- Ensure that a user can pass in an updated title field or content field or pass in both fields as updates

#### How should this be manually tested?
- Setup the repo following the instructions in the README
- Using Postman, pass either only the title or content field to update an entry

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#159714395](https://www.pivotaltracker.com/story/show/159714395)

#### Screenshots (if appropriate)
N/A

#### Questions:
None